### PR TITLE
Fix syntax of example CommonJS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ You must use a dynamic import instead, which must be inside an asynchronous meth
 
 ```js
 (async () => {
-    const delphi = await import("delphi-ai");
+    const { default: delphi } = (await import("delphi-ai"));
     const response = await delphi("Fighting a mummy");
     console.log(response); // "It's wrong"
 })();
 
 // or
 
-import("delphi-ai").then(async (delphi) => {
+import("delphi-ai").then(async ({ default: delphi }) => {
     const response = await delphi("Climbing up the Eiffel Tower");
     console.log(response); // "It's normal"
 });

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You must use a dynamic import instead, which must be inside an asynchronous meth
 
 ```js
 (async () => {
-    const { default: delphi } = (await import("delphi-ai"));
+    const delphi = (await import("delphi-ai")).default;
     const response = await delphi("Fighting a mummy");
     console.log(response); // "It's wrong"
 })();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,14 +13,13 @@ describe(basename(import.meta.url), () => {
 	const goodResponseText = "mock response";
 	const goodResponse = {
 		ok: true,
-		// eslint-disable-next-line @typescript-eslint/require-await
-		json: async () => ({ answer: { text: goodResponseText } }),
+		json: () => Promise.resolve({ answer: { text: goodResponseText } }),
 	} as Response;
 
 	const badResponse = {
 		ok: false,
 		status: 404,
-		statusText: "Not found",
+		statusText: "Not Found",
 	} as Response;
 
 	beforeEach(() => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,7 +31,7 @@ describe(basename(import.meta.url), () => {
 		await delphi("");
 		const url = mockFetch.mock.calls[0][0] as URL;
 		const params = new URLSearchParams(url.search);
-		const input = decodeURIComponent(params.get("action1") ?? "");
+		const input = params.get("action1") ?? "";
 		expect(input).toEqual(" ");
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,7 @@ export default async function (input: string): Promise<string> {
 
 	// Format request URL
 	const url = new URL("https://mosaic-api-frontdoor.apps.allenai.org/predict");
-	url.search = new URLSearchParams({
-		action1: encodeURIComponent(input),
-	}).toString();
+	url.search = new URLSearchParams({ action1: input }).toString();
 
 	// Send request
 	const response = await fetch(url);

--- a/test/api.ts
+++ b/test/api.ts
@@ -1,12 +1,13 @@
+import { error, log } from "node:console";
 import { exit } from "node:process";
 
 import delphi from "../src/index.js";
 
 try {
 	const response = await delphi("Testing an API");
-	console.log(response);
+	log(response);
 }
 catch (err) {
-	console.error(err);
+	error(err);
 	exit(1);
 }


### PR DESCRIPTION
## Changed
- Cleaned up unit and API tests

## Removed
- Redundant manual URI encoding

## Fixed
- Incorrect syntax for example CommonJS imports in README