### PR TITLE
Use setup-node for GitHub workflows

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   api:
     runs-on: ubuntu-latest
-    container:
-        image: node:18
 
     steps:
         - name: Checkout repository
           uses: actions/checkout@v4
+
+        - name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: '18'
       
         - name: Install dependencies
           run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,21 +3,20 @@ name: Publish
 
 on:
   release:
-    types: [released]  
+    types: [released]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container:
-      image: node:18
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup NPM token
+      - name: Setup node
         uses: actions/setup-node@v3
         with:
+          node-version: '18'
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,12 +11,15 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    container:
-      image: node:18
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Using `setup-node` to manage the node version is roughly twice as fast as using a Docker container.