### PR TITLE
Dual package distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,26 +41,23 @@ console.log(response); // "It's impressive"
 
 ### CommonJS
 
-Because ES module imports are asynchronous, this package cannot be imported with a synchronous `require()` call.
-You must use a dynamic import instead, which must be inside an asynchronous method or handled as a `Promise`.
+ES module imports are asynchronous, but CommonJS `require()` calls are synchronous.
+But fear not! This package comes with an alternative export path for projects using CommonJS so you can use `require()`.
 
 ```js
+const delphi = require("delphi-ai").default;
+
 (async () => {
-    const delphi = (await import("delphi-ai")).default;
-    const response = await delphi("Fighting a mummy");
-    console.log(response); // "It's wrong"
+	const response = await delphi("Fighting a mummy");
+	console.log(response); // "It's wrong"
 })();
 
 // or
 
-import("delphi-ai").then(async ({ default: delphi }) => {
-    const response = await delphi("Climbing up the Eiffel Tower");
-    console.log(response); // "It's normal"
+delphi("Climbing up the Eiffel Tower").then((response) => {
+	console.log(response); // "It's normal"
 });
 ```
-
-The recommended way to use this package is from within a project using ES Modules.
-ESM is the official module system for JavaScript. If you are using CommonJS, consider upgrading!
 
 ## Development
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,7 @@ export default [
 		},
 	},
 	{
-		files: ["**/*.ts"],
+		files: ["**/*.ts", "**/*.cts"],
 		plugins: {
 			"@typescript-eslint": typescriptPlugin,
 		},

--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"type": "module",
+	"exports": {
+		"types": {
+			"require": "./dist/index.d.cts",
+			"default": "./dist/index.d.ts"
+		},
+		"default": {
+			"require": "./dist/index.cjs",
+			"default": "./dist/index.js"
+		}
+	},
 	"scripts": {
 		"lint": "eslint .",
 		"build": "tsc",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
 	"name": "delphi-ai",
 	"version": "1.0.2",
 	"description": "API wrapper for the Delphi AI",
+	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"type": "module",
 	"exports": {
 		"types": {
 			"require": "./dist/index.d.cts",
@@ -34,9 +34,7 @@
 	],
 	"author": "Justin McBride",
 	"license": "Apache-2.0",
-	"bugs": {
-		"url": "https://github.com/JstnMcBrd/delphi-ai/issues"
-	},
+	"bugs": "https://github.com/JstnMcBrd/delphi-ai/issues",
 	"homepage": "https://github.com/JstnMcBrd/delphi-ai",
 	"engines": {
 		"node": ">=18"

--- a/src/index.cts
+++ b/src/index.cts
@@ -1,0 +1,9 @@
+/**
+ * @param input The input to send to Delphi AI
+ * @returns The output from Delphi AI
+ * @throws If the API returns a non-200 response
+ */
+export default async function (input: string): Promise<string> {
+	const delphi = (await import("./index.js")).default;
+	return await delphi(input);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["src/**/*.ts"],
+	"include": ["src/**/*.ts", "src/**/*.cts"],
 	"exclude": ["src/**/*.test.ts"],
 	"compilerOptions": {
 		"target": "ES2022",


### PR DESCRIPTION
## Added
- `index.cts` CommonJS import wrapper file
- Alternative export paths for CommonJS `require()` imports

## Changed
- Examples for CommonJS imports in the README