### PR TITLE
Remove 'default' from CommonJS import

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ ES module imports are asynchronous, but CommonJS `require()` calls are synchrono
 But fear not! This package comes with an alternative export path for projects using CommonJS so you can use `require()`.
 
 ```js
-const delphi = require("delphi-ai").default;
+const delphi = require("delphi-ai");
 
 (async () => {
 	const response = await delphi("Fighting a mummy");

--- a/src/index.cts
+++ b/src/index.cts
@@ -3,7 +3,7 @@
  * @returns The output from Delphi AI
  * @throws If the API returns a non-200 response
  */
-export default async function (input: string): Promise<string> {
+export = async function (input: string): Promise<string> {
 	const delphi = (await import("./index.js")).default;
 	return await delphi(input);
 }

--- a/src/index.cts
+++ b/src/index.cts
@@ -3,7 +3,7 @@
  * @returns The output from Delphi AI
  * @throws If the API returns a non-200 response
  */
-export = async function (input: string): Promise<string> {
-	const delphi = (await import("./index.js")).default;
-	return await delphi(input);
+export = async function delphi (input: string): Promise<string> {
+	const delphiESM = (await import("./index.js")).default;
+	return await delphiESM(input);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ interface DelphiAPIResponse {
  * @returns The output from Delphi AI
  * @throws If the API returns a non-200 response
  */
-export default async function (input: string): Promise<string> {
+export default async function delphi (input: string): Promise<string> {
 	// The API does not like empty prompts
 	if (input === "") {
 		input = " ";


### PR DESCRIPTION
## Changed
- Exported functions to have names
- README CommonJS example

## Removed
- The ES-style export from the CommonJS module that required users to specify `.default` when importing using `require()`
