### PR TITLE
Remove build stage from API Status workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -22,8 +22,5 @@ jobs:
         - name: Install dependencies
           run: npm install
 
-        - name: Build
-          run: npm run build
-
         - name: Test API
           run: npm run test-api


### PR DESCRIPTION
## Removed
- Unnecessary build stage from `API Status` GitHub workflow