### PR TITLE
Use node 20 for GitHub workflows

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -17,7 +17,7 @@ jobs:
         - name: Setup node
           uses: actions/setup-node@v3
           with:
-            node-version: '18'
+            node-version: '20'
       
         - name: Install dependencies
           run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ However, it does require Node 18 or higher. Use `node --version` to check your n
 
 ### ES Modules
 
-This package uses ESM, so it is easiest to import from within a project also using ESM.
-
 ```js
 import delphi from "delphi-ai";
 
@@ -40,9 +38,6 @@ console.log(response); // "It's impressive"
 ```
 
 ### CommonJS
-
-ES module imports are asynchronous, but CommonJS `require()` calls are synchronous.
-But fear not! This package comes with an alternative export path for projects using CommonJS so you can use `require()`.
 
 ```js
 const delphi = require("delphi-ai");


### PR DESCRIPTION
## Changed

- GitHub workflows to use node 20

## Removed

- Explanation about ESM vs CJS from the `README`