### PR TITLE
Add pool=forks vitest option to API Status workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -23,4 +23,7 @@ jobs:
           run: npm install
 
         - name: Test API
-          run: npm run test-api
+          run: npm run test-api -- --pool=forks
+          # --pool=forks is necessary to prevent random timeouts
+          # https://github.com/JstnMcBrd/delphi-ai/issues/26
+          # https://github.com/vitest-dev/vitest/issues/2008#issuecomment-1871066901


### PR DESCRIPTION
## Fixed

- API Status workflow occasionally hanging and timing out by using `--pool=forks` vitest option (fixes https://github.com/JstnMcBrd/delphi-ai/issues/26)