### PR TITLE
Standardize ESLint and TypeScript setup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,8 @@ export default [
 		rules: {
 			...typescriptPlugin.configs['strict-type-checked'].rules,
 			...typescriptPlugin.configs['stylistic-type-checked'].rules,
+
+			'no-undef': 0, // handled by TypeScript
 		},
 	},
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,9 @@ export default [
 				NodeJS: true,
 			},
 		},
+		linterOptions: {
+			reportUnusedDisableDirectives: 'error',
+		},
 		rules: {
 			// Recommended
 			...js.configs.recommended.rules,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,9 +18,7 @@ export default [
 			sourceType: 'module',
 			ecmaVersion: 2022,
 			globals: {
-				...globals.node,
-				...globals.es2021, // es2022 is not available (https://github.com/sindresorhus/globals/issues/183)
-				NodeJS: true,
+				...globals.nodeBuiltin,
 			},
 		},
 		linterOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,7 @@ export default [
 		},
 		languageOptions: {
 			sourceType: 'module',
-			ecmaVersion: 2022,
+			ecmaVersion: 'latest',
 			globals: {
 				...globals.nodeBuiltin,
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "2.0.1-alpha",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@stylistic/eslint-plugin": "^1.5.3",
+				"@stylistic/eslint-plugin": "^1.5.4",
 				"@types/node": "^20.10.6",
-				"@typescript-eslint/eslint-plugin": "^6.18.1",
-				"@typescript-eslint/parser": "^6.18.1",
+				"@typescript-eslint/eslint-plugin": "^6.19.0",
+				"@typescript-eslint/parser": "^6.19.0",
 				"eslint": "^8.56.0",
 				"typescript": "^5.3.3",
 				"vitest": "^1.1.1"
@@ -760,15 +760,15 @@
 			"dev": true
 		},
 		"node_modules/@stylistic/eslint-plugin": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.5.3.tgz",
-			"integrity": "sha512-Vee+hHKaCd8DPRoRJTCV+mOFz+zFIaA9QiNJaAvgBzmPkcDnSC7Ewh518fN6SSNe9psS8TDIpcxd1g5v4MSY5A==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.5.4.tgz",
+			"integrity": "sha512-zWPXr+O67GC9KDAFkbL1U9UVqE6Iv69YMKhkIECCmE0GvClUJwdfsimm4XebEDondV7kfjMrTDZaYfrI5aS0Jg==",
 			"dev": true,
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.5.3",
-				"@stylistic/eslint-plugin-jsx": "1.5.3",
-				"@stylistic/eslint-plugin-plus": "1.5.3",
-				"@stylistic/eslint-plugin-ts": "1.5.3"
+				"@stylistic/eslint-plugin-js": "1.5.4",
+				"@stylistic/eslint-plugin-jsx": "1.5.4",
+				"@stylistic/eslint-plugin-plus": "1.5.4",
+				"@stylistic/eslint-plugin-ts": "1.5.4"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -778,9 +778,9 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-js": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.3.tgz",
-			"integrity": "sha512-XlKnm82fD7Sw9kQ6FFigE0tobvptNBXZWsdfoKmUyK7bNxHsAHOFT8zJGY3j3MjZ0Fe7rLTu86hX/vOl0bRRdQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.4.tgz",
+			"integrity": "sha512-3ctWb3NvJNV1MsrZN91cYp2EGInLPSoZKphXIbIRx/zjZxKwLDr9z4LMOWtqjq14li/OgqUUcMq5pj8fgbLoTw==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.11.3",
@@ -796,12 +796,12 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-jsx": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.5.3.tgz",
-			"integrity": "sha512-gKXWFmvg3B4e6G+bVz2p37icjj3gS5lzazZD6oLjmQ2b0Lw527VpnxGjWxQ16keKXtrVzUfebakjskOoALg3CQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.5.4.tgz",
+			"integrity": "sha512-JUfrpCkeBCqt1IZ4QsP4WgxGza4PhK4LPbc0VnCjHKygl+rgqoDAovqOuzFJ49wJ4Ix3r6OIHFuwiBGswZEVvg==",
 			"dev": true,
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "^1.5.3",
+				"@stylistic/eslint-plugin-js": "^1.5.4",
 				"estraverse": "^5.3.0"
 			},
 			"engines": {
@@ -812,25 +812,25 @@
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-plus": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.5.3.tgz",
-			"integrity": "sha512-fuOBySbH4dbfY4Dwvu+zg5y+e0lALHTyQske5+a2zNC8Ejnx4rFlVjYOmaVFtxFhTD4V0vM7o21Ozci0igcxKg==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.5.4.tgz",
+			"integrity": "sha512-dI0Cs5vYX/0uMhQDY+NK0cKQ0Pe9B6jWYxd0Ndud+mNloDaVLrsmJocK4zn+YfhGEDs1E4Nk5uAPZEumIpDuSg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "^6.17.0"
+				"@typescript-eslint/utils": "^6.19.0"
 			},
 			"peerDependencies": {
 				"eslint": "*"
 			}
 		},
 		"node_modules/@stylistic/eslint-plugin-ts": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.5.3.tgz",
-			"integrity": "sha512-/gUEqGo0gpFeu220YmC0788VliKnmTaAz4pI82KA5cUuCp6OzEhGlrNkb1eevMwH0RRgyND20HJxOYvEGlwu+w==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.5.4.tgz",
+			"integrity": "sha512-NZDFVIlVNjuPvhT+0Cidm5IS3emtx338xbJTqs2xfOVRDGTpYwRHhNVEGa1rFOpYHmv0sAj6+OXbMDn7ul0K/g==",
 			"dev": true,
 			"dependencies": {
-				"@stylistic/eslint-plugin-js": "1.5.3",
-				"@typescript-eslint/utils": "^6.17.0"
+				"@stylistic/eslint-plugin-js": "1.5.4",
+				"@typescript-eslint/utils": "^6.19.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -861,16 +861,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
-			"integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.0.tgz",
+			"integrity": "sha512-DUCUkQNklCQYnrBSSikjVChdc84/vMPDQSgJTHBZ64G9bA9w0Crc0rd2diujKbTdp6w2J47qkeHQLoi0rpLCdg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/type-utils": "6.18.1",
-				"@typescript-eslint/utils": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.0",
+				"@typescript-eslint/type-utils": "6.19.0",
+				"@typescript-eslint/utils": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -896,15 +896,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
-			"integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
+			"integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/typescript-estree": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.0",
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/typescript-estree": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -924,13 +924,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
-			"integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.0.tgz",
+			"integrity": "sha512-dO1XMhV2ehBI6QN8Ufi7I10wmUovmLU0Oru3n5LVlM2JuzB4M+dVphCPLkVpKvGij2j/pHBWuJ9piuXx+BhzxQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1"
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -941,13 +941,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
-			"integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.0.tgz",
+			"integrity": "sha512-mcvS6WSWbjiSxKCwBcXtOM5pRkPQ6kcDds/juxcy/727IQr3xMEcwr/YLHW2A2+Fp5ql6khjbKBzOyjuPqGi/w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.18.1",
-				"@typescript-eslint/utils": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.19.0",
+				"@typescript-eslint/utils": "6.19.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -968,9 +968,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
-			"integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.0.tgz",
+			"integrity": "sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -981,13 +981,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
-			"integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.0.tgz",
+			"integrity": "sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/visitor-keys": "6.18.1",
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/visitor-keys": "6.19.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -1009,17 +1009,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
-			"integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.0.tgz",
+			"integrity": "sha512-QR41YXySiuN++/dC9UArYOg4X86OAYP83OWTewpVx5ct1IZhjjgTLocj7QNxGhWoTqknsgpl7L+hGygCO+sdYw==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.18.1",
-				"@typescript-eslint/types": "6.18.1",
-				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/scope-manager": "6.19.0",
+				"@typescript-eslint/types": "6.19.0",
+				"@typescript-eslint/typescript-estree": "6.19.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -1034,12 +1034,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.18.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
-			"integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
+			"version": "6.19.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.0.tgz",
+			"integrity": "sha512-hZaUCORLgubBvtGpp1JEFEazcuEdfxta9j4iUwdSAr7mEsYYAp3EAUyCZk3VEEqGj6W+AV4uWyrDGtrlawAsgQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/types": "6.19.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
 		"dist"
 	],
 	"devDependencies": {
-		"@stylistic/eslint-plugin": "^1.5.3",
+		"@stylistic/eslint-plugin": "^1.5.4",
 		"@types/node": "^20.10.6",
-		"@typescript-eslint/eslint-plugin": "^6.18.1",
-		"@typescript-eslint/parser": "^6.18.1",
+		"@typescript-eslint/eslint-plugin": "^6.19.0",
+		"@typescript-eslint/parser": "^6.19.0",
 		"eslint": "^8.56.0",
 		"typescript": "^5.3.3",
 		"vitest": "^1.1.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"include": ["src"],
-	"exclude": ["**/*.test.ts"],
+	"exclude": ["**/*.test.*"],
 	"compilerOptions": {
 		"target": "ESNext",
 		"module": "Node16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"include": ["src"],
 	"exclude": ["**/*.test.ts"],
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ESNext",
 		"module": "Node16",
 		"outDir": "dist",
 		"declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,11 @@
 		"outDir": "dist",
 		"declaration": true,
 		"strict": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": true,
+		"verbatimModuleSyntax": true,
 	},
 }


### PR DESCRIPTION
### Added
- `reportUnusedDisableDirectives` ESLint option
- More safety-related `tsconfig` options

### Changed
- All ESLint-related dependencies to be up-to-date
- TypeScript and ESLint target to `ESNext`
- `no-undef` ESLint rule to be off for TypeScript files
- Test file ignore in `tsconfig.json` to be generalized

### Removed
- Unnecessary ESLint globals