### PR TITLE
Append search params instead of overwriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
 	"version": "2.0.1-alpha",
 	"description": "API wrapper for the Delphi AI",
 	"keywords": [
+		"api",
 		"delphi",
 		"ai",
-		"api",
 		"ethics",
 		"morals"
 	],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { basename } from 'node:path';
-import { URL, URLSearchParams } from 'node:url';
+import { URL } from 'node:url';
 
 import { afterAll, describe, expect, it, vi } from 'vitest';
 
@@ -29,8 +29,7 @@ describe(basename(import.meta.url), () => {
 		mockFetch.mockResolvedValue(goodResponse);
 		await delphi('');
 		const url = mockFetch.mock.calls[0][0];
-		const params = new URLSearchParams(url.search);
-		const input = params.get('action1') ?? '';
+		const input = url.searchParams.get('action1') ?? '';
 		expect(input).toEqual(' ');
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { URL, URLSearchParams } from 'node:url';
+import { URL } from 'node:url';
 
 interface DelphiAPIResponse {
 	answer: {
@@ -19,7 +19,7 @@ export default async function delphi(input: string): Promise<string> {
 
 	// Format request URL
 	const url = new URL('https://mosaic-api-frontdoor.apps.allenai.org/predict');
-	url.search = new URLSearchParams({ action1: input }).toString();
+	url.searchParams.append('action1', input);
 
 	// Send request
 	const response = await fetch(url);


### PR DESCRIPTION
### Changed

- Search params to be appended instead of overwritten
- Package keywords to be sorted based on GitHub's ordering