### PR TITLE
Upgrade to TypeScript 5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@jstnmcbrd/eslint-config": "^1.0.0",
 				"@types/node": "^20.16.5",
 				"eslint": "^8.57.1",
-				"typescript": "^5.5.4",
+				"typescript": "^5.6.2",
 				"vitest": "^2.1.1"
 			},
 			"engines": {
@@ -4441,9 +4441,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-			"integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@jstnmcbrd/eslint-config": "^1.0.0",
 		"@types/node": "^20.16.5",
 		"eslint": "^8.57.1",
-		"typescript": "^5.5.4",
+		"typescript": "^5.6.2",
 		"vitest": "^2.1.1"
 	},
 	"engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { URL } from 'node:url';
-
 interface DelphiAPIResponse {
 	answer: {
 		text: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
 		"noImplicitReturns": true,
 		"noImplicitOverride": true,
 		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedSideEffectImports": true,
 		"verbatimModuleSyntax": true,
 		"isolatedModules": true,
 		"isolatedDeclarations": true,


### PR DESCRIPTION
Replaces #48 

---

### Added

- New `noUncheckedSideEffectImports` TS config option

### Changed

- `typescript` to latest version

### Removed

- Unnecessary (and incompatible with TS 5.6) node type imports