### PR TITLE
Remove dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: "increase"
+    open-pull-requests-limit: 1000


### PR DESCRIPTION
### Changed

- Dependabot open PR limit to 1000 (effectively removed it)